### PR TITLE
fix: Add global select dropdown styles

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -127,3 +127,14 @@ a.active {
 	height: calc(var(--spacing) * 5);
 	width: calc(var(--spacing) * 5);
 }
+
+/* Theme select styling */
+select {
+	background-color: var(--color-bg);
+	color: var(--color-text);
+}
+
+select option {
+	background-color: var(--color-bg);
+	color: var(--color-text);
+}


### PR DESCRIPTION
I discovered the select dropdown for the dark/light mode switch to be not correctly styled. 

| Old | New |
| -------- | ------- |
| <img width="523" height="442" alt="example_select_old" src="https://github.com/user-attachments/assets/ae051efe-acf5-417e-8e73-a33d28364ba4" />  | <img width="514" height="457" alt="example_select_new" src="https://github.com/user-attachments/assets/ff5901c4-1596-4b1a-bd1e-1181dd5b9fd8" />    |

Proposed change:
- Add global select dropdown styles so they are properly styled also in dark mode

Maybe the styles could also just be added to the dark/light select html tag.
